### PR TITLE
Fix typeinfo passed to GC.addRange.

### DIFF
--- a/source/vibe/container/internal/rctable.d
+++ b/source/vibe/container/internal/rctable.d
@@ -90,7 +90,7 @@ struct RCTable(T, Allocator = IAllocator) {
 		} catch (Exception e) assert(false, e.msg);
 
 		static if (hasIndirections!T && !is(Allocator == GCAllocator))
-			GC.addRange(m_table.ptr, m_table.length * T.sizeof, typeid(T));
+			GC.addRange(m_table.ptr, m_table.length * T.sizeof, typeid(T[]));
 	}
 
 	/// Deallocates without running destructors


### PR DESCRIPTION
After reviewing the code in Druntime, it seems like the dynamic array type needs to be passed to the GC functions. This would mean that there is no way to tell the GC the type of an actual T[] being allocated, but the same issue exists for class references.